### PR TITLE
Add draggable map editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Map Editor features
+- Profiles are stored in localStorage and can be edited in the profile modal.
+- Elements from the current profile are shown on the left panel and can be dragged onto the grid.
+- The grid can be exported as a text map using the Export button.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import SplitButton from './SplitButton';
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import BasicModal from "./BasicModal.jsx";
 import NestedList from "./NestedList.jsx";
 import Box from '@mui/material/Box';
@@ -8,11 +8,17 @@ import { Grid } from '@mui/material';
 import Paper from '@mui/material/Paper';
 import GridSizeControls from './GridSizeControls';
 import Typography from "@mui/material/Typography";
+import Button from '@mui/material/Button';
 
 function App() {
     const [isOpen, setIsOpen] = useState(false);
     const [gridSize, setGridSize] = useState({ x: 3, y: 3 });
-    const profile = useProfile();
+    const { profile } = useProfile();
+    const [grid, setGrid] = useState(() => Array.from({ length: 3 }, () => Array.from({ length: 3 }, () => ' ')));
+
+    useEffect(() => {
+        setGrid(Array.from({ length: gridSize.y }, () => Array.from({ length: gridSize.x }, () => ' ')));
+    }, [gridSize]);
 
     const handleSizeChange = (axis) => (event) => {
         const value = parseInt(event.target.value) || 3;
@@ -27,6 +33,23 @@ function App() {
             ...prev,
             [axis]: newValue
         }));
+    };
+
+    const handleDrop = (row, col, char) => {
+        setGrid(prev => {
+            const copy = prev.map(r => [...r]);
+            copy[row][col] = char;
+            return copy;
+        });
+    };
+
+    const handleExport = () => {
+        const content = grid.map(row => row.join('')).join('\n');
+        const blob = new Blob([content], { type: 'text/plain' });
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = 'map.txt';
+        a.click();
     };
 
     return (
@@ -48,9 +71,27 @@ function App() {
                 borderRadius:'0 20px 20px 0',
                 top:'10%',
                 backgroundColor:'#5a5a5a',
-                width:'20%',
-                height:'80%'
+                width:{xs:'30%', md:'20%'},
+                height:'80%',
+                overflow:'auto'
             }}>
+                {Object.entries(profile.categories).map(([key, value]) => (
+                    value.expandable ?
+                        value.options.map(opt => (
+                            <Box key={key + opt.name}
+                                 draggable
+                                 onDragStart={e => e.dataTransfer.setData('text/plain', opt.character)}
+                                 sx={{color:'white', padding:'4px', cursor:'grab'}}>
+                                {opt.name} ({opt.character})
+                            </Box>
+                        )) :
+                        <Box key={key}
+                             draggable
+                             onDragStart={e => e.dataTransfer.setData('text/plain', value.character)}
+                             sx={{color:'white', padding:'4px', cursor:'grab'}}>
+                            {key} ({value.character})
+                        </Box>
+                ))}
             </Box>
             <Box sx={{
                 position:'absolute',
@@ -58,7 +99,7 @@ function App() {
                 borderRadius:'20px 0 0 20px',
                 top:'10%',
                 backgroundColor:'#5a5a5a',
-                width:'20%',
+                width:{xs:'30%', md:'20%'},
                 height:'80%'
             }}>
                 <GridSizeControls
@@ -66,12 +107,13 @@ function App() {
                     onSizeChange={handleSizeChange}
                     onSliderChange={handleSliderChange}
                 />
+                <Button variant="contained" sx={{mt:2}} onClick={handleExport}>Export</Button>
             </Box>
             <Box sx={{
                 position:'absolute',
                 left:'30%',
                 top:'10%',
-                width:'40%',
+                width:{xs:'90%', md:'40%'},
                 height:"80%",
                 backgroundColor:'#6a6a6a',
                 borderRadius: '20px',
@@ -86,30 +128,38 @@ function App() {
                     padding: 2
                 }}>
                     <Grid container spacing={1} justifyContent={'center'}  height={"100%"} alignItems={'stretch'} direction={'row'} columns={gridSize.x} rows={gridSize.y}>
-                        {[...Array(gridSize.y)].map((_, rowIndex) => (
-                            [...Array(gridSize.x)].map((_, colIndex) => (
+                        {grid.map((row,rowIndex) => (
+                            row.map((cell, colIndex) => (
                                 <Grid size={1} item key={`${rowIndex}-${colIndex}`}>
                                     <Box
+                                        onDragOver={e => e.preventDefault()}
+                                        onDrop={e => handleDrop(rowIndex, colIndex, e.dataTransfer.getData('text/plain'))}
                                         sx={{
                                             height: '100%',
                                             width: '100%',
                                             backgroundColor: 'silver',
                                             borderRadius: '8px',
+                                            display:'flex',
+                                            alignItems:'center',
+                                            justifyContent:'center',
+                                            fontWeight:'bold',
                                             '&:hover': {
                                                 backgroundColor: '#b8b8b8',
                                                 cursor: 'pointer'
                                             }
                                         }}
-                                    />
+                                    >{cell}</Box>
                                 </Grid>
                             ))
                         ))}
                     </Grid>
                 </Box>
             </Box>
-            {isOpen && <BasicModal title={profile.name} isOpen={isOpen} setIsOpen={setIsOpen}>
-                <NestedList/>
-            </BasicModal>}
+            {isOpen && (
+                <BasicModal title={profile.name} isOpen={isOpen} setIsOpen={setIsOpen}>
+                    <NestedList/>
+                </BasicModal>
+            )}
         </div>
     );
 }

--- a/src/NestedList.jsx
+++ b/src/NestedList.jsx
@@ -44,7 +44,14 @@ function ExpandableItem(props) {
     }
 
     const handleAdd = () => {
-        setOptions([...options,{icon: "default", name: name,character: char}]);
+        const newOption = {icon: "default", name: name, character: char};
+        setOptions([...options, newOption]);
+        props.setProfile(prev => {
+            const updated = { ...prev };
+            const opts = updated.categories[props.Category].options || [];
+            updated.categories[props.Category].options = [...opts, newOption];
+            return updated;
+        });
         setName('');
         setChar('');
     }
@@ -102,7 +109,8 @@ ExpandableItem.propTypes = {
     open: PropTypes.bool,
     Category: PropTypes.string,
     Color: PropTypes.string,
-    Icon: PropTypes.string
+    Icon: PropTypes.string,
+    setProfile: PropTypes.func
 };
 
 function SimpleItem(props) {
@@ -136,7 +144,7 @@ SimpleItem.propTypes = {
 
 
 export default function NestedList() {
-    const profile = useProfile();
+    const { profile, setProfile } = useProfile();
     return (
         <List
             sx={{width: '100%', bgcolor: 'background.paper' }}
@@ -145,7 +153,8 @@ export default function NestedList() {
 
         >
             {Object.entries(profile.categories).map(([key, value]) => (
-                value.expandable?<ExpandableItem Category={key} Color={styles.expandable.color} Icon={value.icon} options={value.options||[]}/>:
+                value.expandable?
+                    <ExpandableItem Category={key} Color={styles.expandable.color} Icon={value.icon} options={value.options||[]} setProfile={setProfile} />:
                     <SimpleItem Category={key} Color={styles.simple.color} Icon={value.icon} Character={value.character}/>
             ))}
 

--- a/src/ProfileContext.jsx
+++ b/src/ProfileContext.jsx
@@ -1,12 +1,19 @@
-import React, { createContext, useContext, useState } from 'react';
-import data from './Profiles/default.json';
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import defaultData from './Profiles/default.json';
+import { getProfile, saveProfile } from './useLocalStorage';
 
 const ProfileContext = createContext();
 
 
 export const ProfileProvider = ({ children }) => {
+    const [profile, setProfile] = useState(() => getProfile() || defaultData);
+
+    useEffect(() => {
+        saveProfile(profile);
+    }, [profile]);
+
     return (
-        <ProfileContext.Provider value={ data }>
+        <ProfileContext.Provider value={{ profile, setProfile }}>
             {children}
         </ProfileContext.Provider>
     );

--- a/src/useLocalStorage.js
+++ b/src/useLocalStorage.js
@@ -1,0 +1,9 @@
+export function getProfile() {
+  const stored = localStorage.getItem('profile');
+  return stored ? JSON.parse(stored) : null;
+}
+
+export function saveProfile(profile) {
+  localStorage.setItem('profile', JSON.stringify(profile));
+}
+


### PR DESCRIPTION
## Summary
- store profile in localStorage via context provider
- show profile items in a left sidebar that can be dragged into the map
- allow dropping items into the grid and export the grid as a text file
- minor responsive tweaks and new docs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847726e9e6483269f724642ca3d7cda